### PR TITLE
Support Swift Package Manager

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Chargebee/Classes/Logger/CBLoggerResource.swift
+++ b/Chargebee/Classes/Logger/CBLoggerResource.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Haripriyan on 7/20/20.
 //
-import Foundation
+import UIKit
 
 var deviceModelName: String {
     return UIDevice.modelName

--- a/Chargebee/Classes/Purchase/CBProductsV1.swift
+++ b/Chargebee/Classes/Purchase/CBProductsV1.swift
@@ -5,6 +5,8 @@
 //  Created by CB/IT/01/1039 on 21/09/21.
 //
 
+import Foundation
+
 public typealias ProductIdentifierHandler = (CBResult<CBProductIDWrapper>) -> Void
 
 public struct CBProductIDWrapper {

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Chargebee",
+    platforms: [.iOS(.v9)],
+    products: [
+        .library(name: "Chargebee", targets: ["Chargebee"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "Chargebee",
+            dependencies: [],
+            path: "Chargebee",
+            exclude: [],
+            sources: ["Classes"],
+            resources: [.process("Assets")])
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ It's also available through [CocoaPods](https://cocoapods.org/pods/Chargebee). T
 it, simply add the following line to your Podfile:
 
     pod 'Chargebee'
+    
+### Swift Package Manager
+
+In Xcode, File → Add Packages… and paste the URL of this Git repository into the search box.
+
+    https://github.com/chargebee/chargebee-ios
 
 ## Example project
 


### PR DESCRIPTION
This PR adds a `Package.swift` and fixes a couple of imports to build the app using the Chargebee SDK through SPM. It addresses issue #17.