### PR TITLE
Resolve races between configure() and other calls

### DIFF
--- a/Chargebee/Classes/Configuration/CBEnvironment.swift
+++ b/Chargebee/Classes/Configuration/CBEnvironment.swift
@@ -13,7 +13,7 @@ class CBEnvironment {
     static var sdkKey : String = ""
     static var version : CatalogVersion = .unknown
 
-    static func configure(site: String, publishableApiKey: String, allowErrorLogging: Bool, sdkKey: String? = nil) {
+    static func configure(site: String, publishableApiKey: String, allowErrorLogging: Bool, sdkKey: String? = nil, completion: (() -> Void)?) {
         CBEnvironment.site = site
         CBEnvironment.publishableApiKey = publishableApiKey
         CBEnvironment.allowErrorLogging = allowErrorLogging
@@ -32,6 +32,7 @@ class CBEnvironment {
                     print(error)
                     CBEnvironment.version = .unknown
                 }
+                completion?()
             }
         } 
         

--- a/Chargebee/Classes/Configuration/Chargebee.swift
+++ b/Chargebee/Classes/Configuration/Chargebee.swift
@@ -9,7 +9,7 @@ public class Chargebee {
     public init() {
     }
 
-    public static func configure(site: String, publishableApiKey: String, sdkKey: String? = nil, allowErrorLogging: Bool = true) {
-        CBEnvironment.configure(site: site, publishableApiKey: publishableApiKey, allowErrorLogging: allowErrorLogging, sdkKey: sdkKey)
+    public static func configure(site: String, publishableApiKey: String, sdkKey: String? = nil, allowErrorLogging: Bool = true, completion: (() -> Void)? = nil) {
+        CBEnvironment.configure(site: site, publishableApiKey: publishableApiKey, allowErrorLogging: allowErrorLogging, sdkKey: sdkKey, completion: completion)
     }
 }


### PR DESCRIPTION
`Changebee.configure()` makes an API call, which allows time for other SDK functions to be used and make decisions before configuration is complete. With a completion handler, the app has a chance to defer those other calls until it knows that it's safe.

This addresses #19.