### PR TITLE
Make CBProduct usable by apps

### DIFF
--- a/Chargebee/Classes/Purchase/CBPurchaseManager.swift
+++ b/Chargebee/Classes/Purchase/CBPurchaseManager.swift
@@ -32,6 +32,10 @@ public class CBPurchase: NSObject {
 
 public struct CBProduct {
     public let product: SKProduct
+
+    public init(product: SKProduct) {
+        self.product = product
+    }
 }
 
 extension Array where Element == SKProduct {


### PR DESCRIPTION
A synthesized memberwise init gets "internal" access, not public, resulting in an error when a client app tries to use it.