### PR TITLE
Bump minimum ios version to 11.2

### DIFF
--- a/Chargebee.podspec
+++ b/Chargebee.podspec
@@ -28,7 +28,7 @@ Chargebee’s iOS SDK now has support for making and managing in-app purchase su
   s.authors           = { 'cb-imay' => 'imayaselvan@chargebee.com'}
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '11.2'
   
   s.source_files = 'Chargebee/Classes/**/*'
   s.swift_version = '5.0'


### PR DESCRIPTION
The README says "minimum requirement: ios 11+" and when compiling it turns out the actual limit is 11.2.

This PR bumps the minimum ios version from 8 to 11.2 to match the documentation.