### PR TITLE
Getting process purchase command call from SDK 12 times or more

### DIFF
--- a/Chargebee.podspec
+++ b/Chargebee.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Chargebee'
-  s.version          = '1.0.15'
+  s.version          = '1.0.16'
   s.summary          = 'Chargebee iOS SDK'
 
 # This description is used to generate tags and improve search results.

--- a/Chargebee/Classes/Purchase/CBPurchaseManager.swift
+++ b/Chargebee/Classes/Purchase/CBPurchaseManager.swift
@@ -275,6 +275,7 @@ public extension CBPurchase {
                             completion?(.failure(CBError.defaultSytemError(statusCode: 400, message: "Invalid Purchase")))
                             return
                         }
+                        self.activeProduct = nil
                         completion?(.success((true, receipt.subscriptionId, receipt.planId)))
                     case .error(let error):
                         debugPrint(" Chargebee - Receipt Upload - Failure")

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Choose from the following options to install Chargeee iOS SDK.
 Add the following snippet to the Podfile to install directly from Github.
 
 ```swift
-pod 'Chargebee', :git => 'https://github.com/chargebee/chargebee-ios', :tag => '1.0.5'
+pod 'Chargebee', :git => 'https://github.com/chargebee/chargebee-ios', :tag => '1.0.16'
 ```
 
 ### CocoaPods


### PR DESCRIPTION

SKPaymentQueue Delegate keep calls when App state changes 
so when there is a active product its keep doing purchase so multiple calls happening ,
issue fixed