### PR TITLE
[Fix](metadata mapping issue in CBPlan)

### DIFF
--- a/Chargebee/Classes/Plan/CBPlan.swift
+++ b/Chargebee/Classes/Plan/CBPlan.swift
@@ -41,7 +41,7 @@ public struct CBPlan: Codable {
     public let status: String
     public let taxable: Bool
     public let updatedAt: UInt64
-    public var metadata = [String: String]()
+    public let metadata: [String: String]?
     enum CodingKeys: String, CodingKey {
         case addonApplicability = "addon_applicability"
         case chargeModel = "charge_model"


### PR DESCRIPTION
**Issue:** The issue has occurred while retrieving all the plans and get product identifiers from server. error details( Response has no/invalid body).
**Fix:** fixed by updating meta data mapping in `CBPlan`.