### PR TITLE
Failure case Handling

### DIFF
--- a/Chargebee.podspec
+++ b/Chargebee.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Chargebee'
-  s.version          = '1.0.21'
+  s.version          = '1.0.22'
   s.summary          = 'Chargebee iOS SDK'
 
 # This description is used to generate tags and improve search results.

--- a/Chargebee/Classes/Purchase/CBPurchaseManager.swift
+++ b/Chargebee/Classes/Purchase/CBPurchaseManager.swift
@@ -221,39 +221,99 @@ extension CBPurchase: SKPaymentTransactionObserver {
                 SKPaymentQueue.default().finishTransaction(transaction)
                 receivedRestoredTransaction()
             case .failed:
-                if let error = transaction.error as? SKError {
+                if let error = transaction.error as? SKError{
                     print(error)
                     switch  error.errorCode {
                     case 0:
-                        buyProductHandler?(.failure(CBPurchaseError.unknown))
+                        if let _ = activeProduct?.product.subscriptionPeriod {
+                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                        }else{
+                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.unknown))
+                        }
                     case 1:
-                        buyProductHandler?(.failure(CBPurchaseError.invalidClient))
+                        if let _ = activeProduct?.product.subscriptionPeriod {
+                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                        }else{
+                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidClient))
+                        }
                     case 2:
-                        buyProductHandler?(.failure(CBPurchaseError.userCancelled))
+                        if let _ = activeProduct?.product.subscriptionPeriod {
+                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                        }else{
+                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.userCancelled))
+                        }
                     case 3:
-                        buyProductHandler?(.failure(CBPurchaseError.paymentFailed))
+                        if let _ = activeProduct?.product.subscriptionPeriod {
+                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                        }else{
+                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.paymentFailed))
+                        }
                     case 4:
-                        buyProductHandler?(.failure(CBPurchaseError.paymentNotAllowed))
+                        if let _ = activeProduct?.product.subscriptionPeriod {
+                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                        }else{
+                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.paymentNotAllowed))
+                        }
                     case 5:
-                        buyProductHandler?(.failure(CBPurchaseError.productNotAvailable))
+                        if let _ = activeProduct?.product.subscriptionPeriod {
+                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                        }else{
+                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.productsNotFound))
+                        }
                     case 7:
-                        buyProductHandler?(.failure(CBPurchaseError.networkConnectionFailed))
+                        if let _ = activeProduct?.product.subscriptionPeriod {
+                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                        }else{
+                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.networkConnectionFailed))
+                        }
                     case 8:
-                        buyProductHandler?(.failure(CBPurchaseError.invalidSandbox))
+                        if let _ = activeProduct?.product.subscriptionPeriod {
+                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                        }else{
+                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidSandbox))
+                        }
                     case 9:
-                        buyProductHandler?(.failure(CBPurchaseError.privacyAcknowledgementRequired))
+                        if let _ = activeProduct?.product.subscriptionPeriod {
+                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                        }else{
+                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.privacyAcknowledgementRequired))
+                        }
                     case 11:
-                        buyProductHandler?(.failure(CBPurchaseError.invalidOffer))
+                        if let _ = activeProduct?.product.subscriptionPeriod {
+                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                        }else{
+                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidOffer))
+                        }
                     case 12:
-                        buyProductHandler?(.failure(CBPurchaseError.invalidPromoCode))
+                        if let _ = activeProduct?.product.subscriptionPeriod {
+                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                        }else{
+                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidPromoCode))
+                        }
                     case 13:
-                        buyProductHandler?(.failure(CBPurchaseError.invalidPromoOffer))
+                        if let _ = activeProduct?.product.subscriptionPeriod {
+                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                        }else{
+                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidPromoOffer))
+                        }
                     case 14:
-                        buyProductHandler?(.failure(CBPurchaseError.invalidPrice))
+                        if let _ = activeProduct?.product.subscriptionPeriod {
+                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                        }else{
+                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidPrice))
+                        }
                     case 15:
-                        buyProductHandler?(.failure(CBPurchaseError.userCancelled))
+                        if let _ = activeProduct?.product.subscriptionPeriod {
+                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                        }else{
+                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.userCancelled))
+                        }
                     default:
-                        buyProductHandler?(.failure(error))
+                        if let _ = activeProduct?.product.subscriptionPeriod {
+                            buyProductHandler?(.failure(error))
+                        }else{
+                            buyNonSubscriptionProductHandler?(.failure(error))
+                        }
                     }
                 }
                 SKPaymentQueue.default().finishTransaction(transaction)

--- a/Chargebee/Classes/Purchase/CBPurchaseManager.swift
+++ b/Chargebee/Classes/Purchase/CBPurchaseManager.swift
@@ -225,93 +225,37 @@ extension CBPurchase: SKPaymentTransactionObserver {
                     print(error)
                     switch  error.errorCode {
                     case 0:
-                        if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.unknown))
-                        }else{
-                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.unknown))
-                        }
+                        self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.unknown)
                     case 1:
-                        if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.invalidClient))
-                        }else{
-                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidClient))
-                        }
+                        self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.invalidClient)
                     case 2:
-                        if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.userCancelled))
-                        }else{
-                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.userCancelled))
-                        }
+                        self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.userCancelled)
                     case 3:
-                        if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.paymentFailed))
-                        }else{
-                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.paymentFailed))
-                        }
+                        self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.paymentFailed)
                     case 4:
-                        if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.paymentNotAllowed))
-                        }else{
-                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.paymentNotAllowed))
-                        }
+                        self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.paymentNotAllowed)
                     case 5:
-                        if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.productsNotFound))
-                        }else{
-                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.productsNotFound))
-                        }
+                        self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.productsNotFound)
                     case 7:
-                        if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.networkConnectionFailed))
-                        }else{
-                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.networkConnectionFailed))
-                        }
+                        self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.networkConnectionFailed)
                     case 8:
-                        if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.invalidSandbox))
-                        }else{
-                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidSandbox))
-                        }
+                        self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.invalidSandbox)
                     case 9:
-                        if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.privacyAcknowledgementRequired))
-                        }else{
-                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.privacyAcknowledgementRequired))
-                        }
+                        self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.privacyAcknowledgementRequired)
                     case 11:
-                        if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.invalidOffer))
-                        }else{
-                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidOffer))
-                        }
+                        self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.invalidOffer)
                     case 12:
-                        if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.invalidPromoCode))
-                        }else{
-                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidPromoCode))
-                        }
+                        self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.invalidPromoCode)
                     case 13:
-                        if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.invalidPromoOffer))
-                        }else{
-                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidPromoOffer))
-                        }
+                        self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.invalidPromoOffer)
                     case 14:
-                        if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.invalidPrice))
-                        }else{
-                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidPrice))
-                        }
+                        self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.invalidPrice)
                     case 15:
-                        if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.userCancelled))
-                        }else{
-                            buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.userCancelled))
-                        }
+                        self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.userCancelled)
                     default:
                         if let _ = activeProduct?.product.subscriptionPeriod {
                             buyProductHandler?(.failure(error))
-                        }else{
+                        }else {
                             buyNonSubscriptionProductHandler?(.failure(error))
                         }
                     }
@@ -412,7 +356,14 @@ public extension CBPurchase {
             print("Couldn't read receipt data with error: " + error.localizedDescription)
         }
         return receipt
-        
+    }
+    
+    private func invokeProductHandler(forProduct product: SKProduct?, error: CBPurchaseError) {
+        if let _ = product?.subscriptionPeriod {
+            buyProductHandler?(.failure(error))
+        }else {
+            buyNonSubscriptionProductHandler?(.failure(error))
+        }
     }
 }
 

--- a/Chargebee/Classes/Purchase/CBPurchaseManager.swift
+++ b/Chargebee/Classes/Purchase/CBPurchaseManager.swift
@@ -222,7 +222,7 @@ extension CBPurchase: SKPaymentTransactionObserver {
                 receivedRestoredTransaction()
             case .failed:
                 if let error = transaction.error as? SKError{
-                    print(error)
+                    debugPrint("Error :",error)
                     switch  error.errorCode {
                     case 0:
                         self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.unknown)
@@ -235,7 +235,7 @@ extension CBPurchase: SKPaymentTransactionObserver {
                     case 4:
                         self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.paymentNotAllowed)
                     case 5:
-                        self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.productsNotFound)
+                        self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.productNotAvailable)
                     case 7:
                         self.invokeProductHandler(forProduct: self.activeProduct?.product, error: CBPurchaseError.networkConnectionFailed)
                     case 8:

--- a/Chargebee/Classes/Purchase/CBPurchaseManager.swift
+++ b/Chargebee/Classes/Purchase/CBPurchaseManager.swift
@@ -232,79 +232,79 @@ extension CBPurchase: SKPaymentTransactionObserver {
                         }
                     case 1:
                         if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                            buyProductHandler?(.failure(CBPurchaseError.invalidClient))
                         }else{
                             buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidClient))
                         }
                     case 2:
                         if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                            buyProductHandler?(.failure(CBPurchaseError.userCancelled))
                         }else{
                             buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.userCancelled))
                         }
                     case 3:
                         if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                            buyProductHandler?(.failure(CBPurchaseError.paymentFailed))
                         }else{
                             buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.paymentFailed))
                         }
                     case 4:
                         if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                            buyProductHandler?(.failure(CBPurchaseError.paymentNotAllowed))
                         }else{
                             buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.paymentNotAllowed))
                         }
                     case 5:
                         if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                            buyProductHandler?(.failure(CBPurchaseError.productsNotFound))
                         }else{
                             buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.productsNotFound))
                         }
                     case 7:
                         if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                            buyProductHandler?(.failure(CBPurchaseError.networkConnectionFailed))
                         }else{
                             buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.networkConnectionFailed))
                         }
                     case 8:
                         if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                            buyProductHandler?(.failure(CBPurchaseError.invalidSandbox))
                         }else{
                             buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidSandbox))
                         }
                     case 9:
                         if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                            buyProductHandler?(.failure(CBPurchaseError.privacyAcknowledgementRequired))
                         }else{
                             buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.privacyAcknowledgementRequired))
                         }
                     case 11:
                         if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                            buyProductHandler?(.failure(CBPurchaseError.invalidOffer))
                         }else{
                             buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidOffer))
                         }
                     case 12:
                         if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                            buyProductHandler?(.failure(CBPurchaseError.invalidPromoCode))
                         }else{
                             buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidPromoCode))
                         }
                     case 13:
                         if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                            buyProductHandler?(.failure(CBPurchaseError.invalidPromoOffer))
                         }else{
                             buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidPromoOffer))
                         }
                     case 14:
                         if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                            buyProductHandler?(.failure(CBPurchaseError.invalidPrice))
                         }else{
                             buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.invalidPrice))
                         }
                     case 15:
                         if let _ = activeProduct?.product.subscriptionPeriod {
-                            buyProductHandler?(.failure(CBPurchaseError.unknown))
+                            buyProductHandler?(.failure(CBPurchaseError.userCancelled))
                         }else{
                             buyNonSubscriptionProductHandler?(.failure(CBPurchaseError.userCancelled))
                         }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Choose from the following options to install Chargeee iOS SDK.
 Add the following snippet to the Podfile to install directly from Github.
 
 ```swift
-pod 'Chargebee', :git => 'https://github.com/chargebee/chargebee-ios', :tag => '1.0.21'
+pod 'Chargebee', :git => 'https://github.com/chargebee/chargebee-ios', :tag => '1.0.22'
 ```
 
 ### CocoaPods


### PR DESCRIPTION
**Bug Description:**
For one-time Purchases on the failure of purchases the wrong handler is invoked

**Root Cause:** 
we have both subscriptions and non-subscriptions then for Non-subscriptions , subscriptions handler is invoked for one-time purchases also i.e **buyProductHandler** 

**Solution:**
 so updated with the correct handler **buyNonSubscriptionProductHandler**