### PR TITLE
Show Subscriptions Management Settings Sheet

### DIFF
--- a/Chargebee.podspec
+++ b/Chargebee.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Chargebee'
-  s.version          = '1.0.22'
+  s.version          = '1.0.23'
   s.summary          = 'Chargebee iOS SDK'
 
 # This description is used to generate tags and improve search results.

--- a/Chargebee.xcodeproj/project.pbxproj
+++ b/Chargebee.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		FB5363EB29BEE25600E3AC9A /* CBRestorePurchaseResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5363EA29BEE25600E3AC9A /* CBRestorePurchaseResource.swift */; };
 		FB5363ED29BEE28200E3AC9A /* RestoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5363EC29BEE28200E3AC9A /* RestoreError.swift */; };
 		FB5363EF29BEE29800E3AC9A /* BackgroundOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5363EE29BEE29800E3AC9A /* BackgroundOperationQueue.swift */; };
+		FB7B545D2A38666B00FBBCB5 /* UIApplication+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7B545C2A38666B00FBBCB5 /* UIApplication+Settings.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -123,6 +124,7 @@
 		FB5363EA29BEE25600E3AC9A /* CBRestorePurchaseResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBRestorePurchaseResource.swift; sourceTree = "<group>"; };
 		FB5363EC29BEE28200E3AC9A /* RestoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreError.swift; sourceTree = "<group>"; };
 		FB5363EE29BEE29800E3AC9A /* BackgroundOperationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundOperationQueue.swift; sourceTree = "<group>"; };
+		FB7B545C2A38666B00FBBCB5 /* UIApplication+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Settings.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -191,6 +193,7 @@
 		2BF2D4A529A3B8E300E22D21 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				FB7B545F2A38678700FBBCB5 /* UIApplicationSettings */,
 				FB5363E129BB3A2700E3AC9A /* Restore */,
 				2BF2D4A629A3B8E300E22D21 /* Token */,
 				2BF2D4AF29A3B8E300E22D21 /* Configuration */,
@@ -379,6 +382,14 @@
 			path = Restore;
 			sourceTree = "<group>";
 		};
+		FB7B545F2A38678700FBBCB5 /* UIApplicationSettings */ = {
+			isa = PBXGroup;
+			children = (
+				FB7B545C2A38666B00FBBCB5 /* UIApplication+Settings.swift */,
+			);
+			path = UIApplicationSettings;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -494,6 +505,7 @@
 				2BF2D4D929A3B8E300E22D21 /* CBPaymentDetail.swift in Sources */,
 				2BF2D4F129A3B8E300E22D21 /* CBItemListResource.swift in Sources */,
 				2BF2D4F929A3B8E300E22D21 /* CBAuthentication.swift in Sources */,
+				FB7B545D2A38666B00FBBCB5 /* UIApplication+Settings.swift in Sources */,
 				2BF2D4EE29A3B8E300E22D21 /* CBEntitlementResource.swift in Sources */,
 				2BF2D4F529A3B8E300E22D21 /* CBProductsV2.swift in Sources */,
 				2BF2D4E529A3B8E300E22D21 /* CBValidateReceiptResource.swift in Sources */,

--- a/Chargebee.xcodeproj/project.pbxproj
+++ b/Chargebee.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		FB5363ED29BEE28200E3AC9A /* RestoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5363EC29BEE28200E3AC9A /* RestoreError.swift */; };
 		FB5363EF29BEE29800E3AC9A /* BackgroundOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5363EE29BEE29800E3AC9A /* BackgroundOperationQueue.swift */; };
 		FB7B545D2A38666B00FBBCB5 /* UIApplication+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7B545C2A38666B00FBBCB5 /* UIApplication+Settings.swift */; };
+		FB8540C62A49C06600DF535D /* ManageSubscriptionsSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB8540C52A49C06600DF535D /* ManageSubscriptionsSettingsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -125,6 +126,7 @@
 		FB5363EC29BEE28200E3AC9A /* RestoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreError.swift; sourceTree = "<group>"; };
 		FB5363EE29BEE29800E3AC9A /* BackgroundOperationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundOperationQueue.swift; sourceTree = "<group>"; };
 		FB7B545C2A38666B00FBBCB5 /* UIApplication+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Settings.swift"; sourceTree = "<group>"; };
+		FB8540C52A49C06600DF535D /* ManageSubscriptionsSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsSettingsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -358,6 +360,7 @@
 				2BF2D50129A3B8EE00E22D21 /* CBPlansTest.swift */,
 				2BF2D50229A3B8EE00E22D21 /* PurchaseManagerTest.swift */,
 				2BF2D50329A3B8EE00E22D21 /* chargebee_iosTests.swift */,
+				FB8540C52A49C06600DF535D /* ManageSubscriptionsSettingsTests.swift */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -554,6 +557,7 @@
 				2BF2D50729A3B8EE00E22D21 /* SubscriptionTest.swift in Sources */,
 				2BF2D50429A3B8EE00E22D21 /* CBItemsTest.swift in Sources */,
 				2BF2D50B29A3B8EE00E22D21 /* chargebee_iosTests.swift in Sources */,
+				FB8540C62A49C06600DF535D /* ManageSubscriptionsSettingsTests.swift in Sources */,
 				2BF2D50929A3B8EE00E22D21 /* CBPlansTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Chargebee/Classes/Configuration/Chargebee.swift
+++ b/Chargebee/Classes/Configuration/Chargebee.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import StoreKit
 
 public class Chargebee {
     public static let shared = Chargebee()
@@ -102,4 +103,11 @@ public class Chargebee {
         CBToken().tokenize(options: paymentDetail, completion: onSuccess, onError: onError)
     }
     
+   public func showManageSubscriptionsSettings() {
+        if #available(iOS 15.0, *) {
+            UIApplication.showManageSubscriptions()
+        } else {
+            UIApplication.showExternalManageSubscriptions()
+        }
+    }
 }

--- a/Chargebee/Classes/Purchase/CBPurchaseManager.swift
+++ b/Chargebee/Classes/Purchase/CBPurchaseManager.swift
@@ -163,14 +163,6 @@ public extension CBPurchase {
             }
         }
     }
-    
-    func showManageSubscriptionsSettings() {
-        if #available(iOS 15.0, *) {
-            UIApplication.showManageSubscriptions()
-        } else {
-            UIApplication.showExternalManageSubscriptions()
-        }
-    }
 }
 
 // MARK: - Private methods

--- a/Chargebee/Classes/Purchase/CBPurchaseManager.swift
+++ b/Chargebee/Classes/Purchase/CBPurchaseManager.swift
@@ -168,7 +168,7 @@ public extension CBPurchase {
         if #available(iOS 15.0, *) {
             UIApplication.showManageSubscriptions()
         } else {
-            // Fallback on earlier versions
+            UIApplication.showExternalManageSubscriptions()
         }
     }
 }

--- a/Chargebee/Classes/Purchase/CBPurchaseManager.swift
+++ b/Chargebee/Classes/Purchase/CBPurchaseManager.swift
@@ -163,6 +163,14 @@ public extension CBPurchase {
             }
         }
     }
+    
+    func showManageSubscriptionsSettings() {
+        if #available(iOS 15.0, *) {
+            UIApplication.showManageSubscriptions()
+        } else {
+            // Fallback on earlier versions
+        }
+    }
 }
 
 // MARK: - Private methods

--- a/Chargebee/Classes/UIApplicationSettings/UIApplication+Settings.swift
+++ b/Chargebee/Classes/UIApplicationSettings/UIApplication+Settings.swift
@@ -10,11 +10,13 @@ import UIKit
 import StoreKit
 
 extension UIApplication {
+    //This is to Open Appstore App Account settings Page
     @objc class func openAppleIDSubscriptionsPage() {
         guard let url = URL(string: "https://apps.apple.com/account/subscriptions") else { return }
         self.shared.open(url, options: [:], completionHandler: nil)
     }
     
+    // This opens Subscriptions Management settings
     @available(iOS 15.0, *)
     @objc class func showManageSubscriptions() {
         guard let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
@@ -31,10 +33,4 @@ extension UIApplication {
             }
         }
     }
-    
-    @objc class func openAppStoreSettings() {
-        guard let url = URL(string: "itms-ui://") else { return }
-        self.shared.open(url, options: [:], completionHandler: nil)
-    }
-
 }

--- a/Chargebee/Classes/UIApplicationSettings/UIApplication+Settings.swift
+++ b/Chargebee/Classes/UIApplicationSettings/UIApplication+Settings.swift
@@ -10,18 +10,17 @@ import UIKit
 import StoreKit
 
 extension UIApplication {
-    //This is to Open Appstore App Account settings Page
-    @objc class func openAppleIDSubscriptionsPage() {
+
+    @objc class func showExternalManageSubscriptions() {
         guard let url = URL(string: "https://apps.apple.com/account/subscriptions") else { return }
         self.shared.open(url, options: [:], completionHandler: nil)
     }
     
-    // This opens Subscriptions Management settings
     @available(iOS 15.0, *)
     @objc class func showManageSubscriptions() {
         guard let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
               !ProcessInfo.processInfo.isiOSAppOnMac else {
-                  UIApplication.openAppleIDSubscriptionsPage()
+                  UIApplication.showExternalManageSubscriptions()
                   return
         }
         
@@ -29,7 +28,7 @@ extension UIApplication {
             do {
                 try await AppStore.showManageSubscriptions(in: scene)
             } catch {
-                UIApplication.openAppleIDSubscriptionsPage()
+                UIApplication.showExternalManageSubscriptions()
             }
         }
     }

--- a/Chargebee/Classes/UIApplicationSettings/UIApplication+Settings.swift
+++ b/Chargebee/Classes/UIApplicationSettings/UIApplication+Settings.swift
@@ -1,0 +1,40 @@
+//
+//  UIApplication+Settings.swift
+//  Chargebee
+//
+//  Created by ramesh_g on 13/06/23.
+//
+
+import Foundation
+import UIKit
+import StoreKit
+
+extension UIApplication {
+    @objc class func openAppleIDSubscriptionsPage() {
+        guard let url = URL(string: "https://apps.apple.com/account/subscriptions") else { return }
+        self.shared.open(url, options: [:], completionHandler: nil)
+    }
+    
+    @available(iOS 15.0, *)
+    @objc class func showManageSubscriptions() {
+        guard let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+              !ProcessInfo.processInfo.isiOSAppOnMac else {
+                  UIApplication.openAppleIDSubscriptionsPage()
+                  return
+        }
+        
+        Task {
+            do {
+                try await AppStore.showManageSubscriptions(in: scene)
+            } catch {
+                UIApplication.openAppleIDSubscriptionsPage()
+            }
+        }
+    }
+    
+    @objc class func openAppStoreSettings() {
+        guard let url = URL(string: "itms-ui://") else { return }
+        self.shared.open(url, options: [:], completionHandler: nil)
+    }
+
+}

--- a/ChargebeeTests/UnitTests/ManageSubscriptionsSettingsTests.swift
+++ b/ChargebeeTests/UnitTests/ManageSubscriptionsSettingsTests.swift
@@ -1,0 +1,28 @@
+//
+//  ManageSubscriptionsSettingsTests.swift
+//  ChargebeeTests
+//
+//  Created by ramesh_g on 26/06/23.
+//
+
+import XCTest
+@testable import Chargebee
+
+final class ManageSubscriptionsSettingsTests: XCTestCase {
+    
+    override  func  setUp() {
+        super.setUp()
+    }
+    override  func  tearDown() {
+        super.tearDown()
+    }
+    
+    func  test_showManageSubscriptions() {
+        XCTAssertNotNil(UIApplication.showManageSubscriptions())
+    }
+    
+    func  test_showExternalManageSubscriptions() {
+        XCTAssertNotNil(UIApplication.showExternalManageSubscriptions())
+    }
+    
+}

--- a/Example/Chargebee/CBSDKOptionsViewController.swift
+++ b/Example/Chargebee/CBSDKOptionsViewController.swift
@@ -14,7 +14,7 @@ final class CBSDKOptionsViewController: UIViewController, UITextFieldDelegate {
     private var items: [CBItemWrapper] = []
     private var plans: [CBPlan] = []
 
-    private lazy var actions: [ClientAction] = [.initializeInApp, .getAllPlan, .getPlan, .getItems, .getItem, .getEntitlements, .getAddon, .createToken, .getProductIDs, .getProducts, .getSubscriptionStatus ,.restore]
+    private lazy var actions: [ClientAction] = [.initializeInApp, .getAllPlan, .getPlan, .getItems, .getItem, .getEntitlements, .getAddon, .createToken, .getProductIDs, .getProducts, .getSubscriptionStatus ,.restore,.ManageSubscriptions]
 
     @IBOutlet private weak var tableView: UITableView! {
         didSet {
@@ -231,6 +231,8 @@ extension CBSDKOptionsViewController: UITableViewDelegate, UITableViewDataSource
                     }
                 }
             }
+        case .ManageSubscriptions:
+            CBPurchase.shared.showManageSubscriptionsSettings()
         }
     }
 }
@@ -265,6 +267,7 @@ enum ClientAction {
     case getItem
     case getEntitlements
     case restore
+    case ManageSubscriptions
 
 }
 
@@ -297,6 +300,8 @@ extension ClientAction {
             return "Get Apple Specific Product Identifiers"
         case .restore:
             return "Restore Purcahses"
+        case .ManageSubscriptions:
+            return "ManageSubscriptions"
         }
 
     }

--- a/Example/Chargebee/CBSDKOptionsViewController.swift
+++ b/Example/Chargebee/CBSDKOptionsViewController.swift
@@ -14,7 +14,7 @@ final class CBSDKOptionsViewController: UIViewController, UITextFieldDelegate {
     private var items: [CBItemWrapper] = []
     private var plans: [CBPlan] = []
 
-    private lazy var actions: [ClientAction] = [.initializeInApp, .getAllPlan, .getPlan, .getItems, .getItem, .getEntitlements, .getAddon, .createToken, .getProductIDs, .getProducts, .getSubscriptionStatus ,.restore,.ManageSubscriptions]
+    private lazy var actions: [ClientAction] = [.initializeInApp, .getAllPlan, .getPlan, .getItems, .getItem, .getEntitlements, .getAddon, .createToken, .getProductIDs, .getProducts, .getSubscriptionStatus ,.restore,.manageSubscriptions]
 
     @IBOutlet private weak var tableView: UITableView! {
         didSet {
@@ -231,7 +231,7 @@ extension CBSDKOptionsViewController: UITableViewDelegate, UITableViewDataSource
                     }
                 }
             }
-        case .ManageSubscriptions:
+        case .manageSubscriptions:
             CBPurchase.shared.showManageSubscriptionsSettings()
         }
     }
@@ -267,7 +267,7 @@ enum ClientAction {
     case getItem
     case getEntitlements
     case restore
-    case ManageSubscriptions
+    case manageSubscriptions
 
 }
 
@@ -300,7 +300,7 @@ extension ClientAction {
             return "Get Apple Specific Product Identifiers"
         case .restore:
             return "Restore Purcahses"
-        case .ManageSubscriptions:
+        case .manageSubscriptions:
             return "ManageSubscriptions"
         }
 

--- a/Example/Chargebee/CBSDKOptionsViewController.swift
+++ b/Example/Chargebee/CBSDKOptionsViewController.swift
@@ -232,7 +232,7 @@ extension CBSDKOptionsViewController: UITableViewDelegate, UITableViewDataSource
                 }
             }
         case .manageSubscriptions:
-            CBPurchase.shared.showManageSubscriptionsSettings()
+            Chargebee.shared.showManageSubscriptionsSettings()
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Choose from the following options to install Chargeee iOS SDK.
 Add the following snippet to the Podfile to install directly from Github.
 
 ```swift
-pod 'Chargebee', :git => 'https://github.com/chargebee/chargebee-ios', :tag => '1.0.22'
+pod 'Chargebee', :git => 'https://github.com/chargebee/chargebee-ios', :tag => '1.0.23'
 ```
 
 ### CocoaPods


### PR DESCRIPTION
Pr Type: This is a New Feature 

**Problem Without this feature:**
If user  wants to upgrade or downgrade a plan he should go outside the App and should go to settings and open this  management Subscription tab.

**Feature Description:**
Proving flexibility for developers to display management subscription Sheet within App.

**Changes added to SDK:**
SDK Provides a Public method ,on invoking this method it will open Manage Subscriptions Sheet within App.
     * Method Name : showManageSubscriptionsSettings()

**Jira :** https://mychargebee.atlassian.net/browse/OMNISUB-5480

