### PR TITLE
Adding Customer Object to Receipt Validation Method 

### DIFF
--- a/Chargebee/Classes/Purchase/CBPurchaseManager.swift
+++ b/Chargebee/Classes/Purchase/CBPurchaseManager.swift
@@ -212,9 +212,9 @@ extension CBPurchase: SKPaymentTransactionObserver {
                 SKPaymentQueue.default().finishTransaction(transaction)
                 if let product = activeProduct {
                     if let _ = product.product.subscriptionPeriod {
-                        validateReceipt(product, completion: buyProductHandler)
+                        validateReceipt(product,customer: customer, completion: buyProductHandler)
                     }else{
-                        validateReceiptForNonSubscriptions(product, self.productType, completion: buyNonSubscriptionProductHandler)
+                        validateReceiptForNonSubscriptions(product, self.productType,customer: customer, completion: buyNonSubscriptionProductHandler)
                     }
                 }
             case .restored:
@@ -285,10 +285,10 @@ extension CBPurchase: SKPaymentTransactionObserver {
 public extension CBPurchase {
     
     func validateReceiptForNonSubscriptions(_ product: CBProduct?,_ productType:
-         ProductType?, completion: ((Result<NonSubscription, Error>) -> Void)?) {
+                                            ProductType?,customer: CBCustomer? = nil, completion: ((Result<NonSubscription, Error>) -> Void)?) {
         self.productType = productType
         
-        guard let receipt = getReceipt(product: product?.product) else {
+        guard let receipt = getReceipt(product: product?.product,customer: customer) else {
             debugPrint("Couldn't read receipt data with error")
             completion?(.failure(CBError.defaultSytemError(statusCode: 0, message: "Could not read receipt data")))
             return
@@ -309,9 +309,9 @@ public extension CBPurchase {
         }
     }
     
-    func validateReceipt(_ product: CBProduct?,completion: ((Result<(status:Bool, subscriptionId:String?, planId:String?), Error>) -> Void)?) {
+    func validateReceipt(_ product: CBProduct?,customer: CBCustomer? = nil,completion: ((Result<(status:Bool, subscriptionId:String?, planId:String?), Error>) -> Void)?) {
         
-        guard let receipt = getReceipt(product: product?.product) else {
+        guard let receipt = getReceipt(product: product?.product,customer: customer) else {
             debugPrint("Couldn't read receipt data with error")
             completion?(.failure(CBError.defaultSytemError(statusCode: 0, message: "Could not read receipt data")))
             return
@@ -336,7 +336,7 @@ public extension CBPurchase {
         }
     }
     
-    private func getReceipt(product: SKProduct?) -> CBReceipt? {
+    private func getReceipt(product: SKProduct?, customer: CBCustomer? = nil) -> CBReceipt? {
         var receipt: CBReceipt?
         guard let appStoreReceiptURL = Bundle.main.appStoreReceiptURL,
               FileManager.default.fileExists(atPath: appStoreReceiptURL.path) else {

--- a/Chargebee/Classes/Purchase/CBPurchaseManager.swift
+++ b/Chargebee/Classes/Purchase/CBPurchaseManager.swift
@@ -212,9 +212,9 @@ extension CBPurchase: SKPaymentTransactionObserver {
                 SKPaymentQueue.default().finishTransaction(transaction)
                 if let product = activeProduct {
                     if let _ = product.product.subscriptionPeriod {
-                        validateReceipt(product,customer: customer, completion: buyProductHandler)
+                        validateReceipt(product,customer: self.customer, completion: buyProductHandler)
                     }else{
-                        validateReceiptForNonSubscriptions(product, self.productType,customer: customer, completion: buyNonSubscriptionProductHandler)
+                        validateReceiptForNonSubscriptions(product, self.productType,customer: self.customer, completion: buyNonSubscriptionProductHandler)
                     }
                 }
             case .restored:

--- a/Example/Chargebee/CBSDKProductsTableViewController.swift
+++ b/Example/Chargebee/CBSDKProductsTableViewController.swift
@@ -64,7 +64,7 @@ final class CBSDKProductsTableViewController: UITableViewController, UITextField
     func validateReceiptForNonSubscriptions(_ product: CBProduct){
         
         if let type = CBDemoPersistance.getProductTypeFromCache()  {
-            CBPurchase.shared.validateReceiptForNonSubscriptions(product,type) { result in
+            CBPurchase.shared.validateReceiptForNonSubscriptions(product,type,customer: nil) { result in
                 switch result {
                 case .success(let result):
                     if CBDemoPersistance.isPurchaseProductIDAvailable(){
@@ -84,7 +84,7 @@ final class CBSDKProductsTableViewController: UITableViewController, UITextField
     }
     
     func ValidateReceipt(_ product: CBProduct){
-        CBPurchase.shared.validateReceipt(product) { result in
+        CBPurchase.shared.validateReceipt(product,customer: nil) { result in
             switch result {
             case .success(let result):
                 print(result.status )

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Use the function available for the retry mechanism.
 **Function for subscriptions**
 
 ```swift
-CBPurchase.shared.validateReceipt(product) { result in
+CBPurchase.shared.validateReceipt(product,customer: nil) { result in
       switch result {
       case .success(let result):
         print(result.status )
@@ -286,7 +286,7 @@ CBPurchase.shared.validateReceipt(product) { result in
 **Function for one-time purchases**
 
 ```swift
-CBPurchase.shared.validateReceiptForNonSubscriptions(product,type) { result in
+CBPurchase.shared.validateReceiptForNonSubscriptions(product,,type,customer: nil) { result in
         switch result {
         case .success(let result):
           // Clear persisted product details once the validation succeeds.

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ These are the possible error codes and their descriptions:
 Receipt validation is crucial to ensure that the purchases made by your users are synced with Chargebee. In rare cases, when a purchase is made at the Apple App Store, and the network connection goes off, the purchase details may not be updated in Chargebee. In such cases, you can use a retry mechanism by following these steps:
 -   Add a network observer, as shown in the example project.
 -   Save the product identifier in the cache once the purchase is initiated and clear the cache once the purchase is successful.
--   When the network connectivity is lost after the purchase is completed at Apple App Store but not synced with Chargebee, retrieve the product ID from the cache once the network connection is back and initiate `validateReceipt()`/`validateReceiptForNonSubscriptions()` by passing `CBProduct` as input. This will validate the purchase receipt and sync the purchase in Chargebee as a subscription or one-time purchase.
+-   When the network connectivity is lost after the purchase is completed at Apple App Store but not synced with Chargebee, retrieve the product ID from the cache once the network connection is back and initiate `validateReceipt()`/`validateReceiptForNonSubscriptions()` by passing `CBProduct` and `CBCustomer(Optional)` as input. This will validate the purchase receipt and sync the purchase in Chargebee as a subscription or one-time purchase.
 For subscriptions, use the function `validateReceipt()`; for one-time purchases, use the function `validateReceiptForNonSubscriptions()`.
 
 Use the function available for the retry mechanism.

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ CBPurchase.shared.validateReceipt(product,customer: nil) { result in
 **Function for one-time purchases**
 
 ```swift
-CBPurchase.shared.validateReceiptForNonSubscriptions(product,,type,customer: nil) { result in
+CBPurchase.shared.validateReceiptForNonSubscriptions(product,type,customer: nil) { result in
         switch result {
         case .success(let result):
           // Clear persisted product details once the validation succeeds.


### PR DESCRIPTION
**Bug Description :**
This helps to record customer inofmration when trying to validate or update receipt to chargebee manually.


**SDK Changes:**
Added customer object as optional Param to validate Receipt public method
