### PR TITLE
Verify_App / Authenticate Call Optimised With Local Cache

### DIFF
--- a/Chargebee.podspec
+++ b/Chargebee.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Chargebee'
-  s.version          = '1.0.25'
+  s.version          = '1.0.26'
   s.summary          = 'Chargebee iOS SDK'
 
 # This description is used to generate tags and improve search results.

--- a/Chargebee.xcodeproj/project.pbxproj
+++ b/Chargebee.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		FB5363EF29BEE29800E3AC9A /* BackgroundOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5363EE29BEE29800E3AC9A /* BackgroundOperationQueue.swift */; };
 		FB7B545D2A38666B00FBBCB5 /* UIApplication+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7B545C2A38666B00FBBCB5 /* UIApplication+Settings.swift */; };
 		FB8540C62A49C06600DF535D /* ManageSubscriptionsSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB8540C52A49C06600DF535D /* ManageSubscriptionsSettingsTests.swift */; };
+		FBAD3EC22A78CC0A00FFD672 /* CBCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBAD3EC12A78CC0A00FFD672 /* CBCache.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -127,6 +128,7 @@
 		FB5363EE29BEE29800E3AC9A /* BackgroundOperationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundOperationQueue.swift; sourceTree = "<group>"; };
 		FB7B545C2A38666B00FBBCB5 /* UIApplication+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Settings.swift"; sourceTree = "<group>"; };
 		FB8540C52A49C06600DF535D /* ManageSubscriptionsSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsSettingsTests.swift; sourceTree = "<group>"; };
+		FBAD3EC12A78CC0A00FFD672 /* CBCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBCache.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -195,6 +197,7 @@
 		2BF2D4A529A3B8E300E22D21 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				FBAD3EC02A78CBEC00FFD672 /* Cache */,
 				FB7B545F2A38678700FBBCB5 /* UIApplicationSettings */,
 				FB5363E129BB3A2700E3AC9A /* Restore */,
 				2BF2D4A629A3B8E300E22D21 /* Token */,
@@ -393,6 +396,14 @@
 			path = UIApplicationSettings;
 			sourceTree = "<group>";
 		};
+		FBAD3EC02A78CBEC00FFD672 /* Cache */ = {
+			isa = PBXGroup;
+			children = (
+				FBAD3EC12A78CC0A00FFD672 /* CBCache.swift */,
+			);
+			path = Cache;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -526,6 +537,7 @@
 				2BF2D4E729A3B8E300E22D21 /* CBPlanResource.swift in Sources */,
 				2BF2D4FA29A3B8E300E22D21 /* CBAuthenticationResource.swift in Sources */,
 				2BF2D4DC29A3B8E300E22D21 /* CBToken.swift in Sources */,
+				FBAD3EC22A78CC0A00FFD672 /* CBCache.swift in Sources */,
 				FB5363E929BEE1BC00E3AC9A /* CBRestorePurchaseManager.swift in Sources */,
 				2BF2D4DD29A3B8E300E22D21 /* StripeTokenResource.swift in Sources */,
 				2BF2D4EA29A3B8E300E22D21 /* CBAPIRequest.swift in Sources */,

--- a/Chargebee/Classes/Authentication/CBAuthentication.swift
+++ b/Chargebee/Classes/Authentication/CBAuthentication.swift
@@ -46,21 +46,21 @@ extension CBAuthenticationManager {
             return onError(CBError.defaultSytemError(statusCode: 400, message: "SDK Key is empty"))
         }
         
-        if CBCache.shared.isCacheDataAvailable(key: key) {
-            CBCache.shared.readConfigDetails(key: key, logger: logger) { status in
+        if CBCache.shared.isCacheDataAvailable() {
+            CBCache.shared.readConfigDetails(logger: logger) { status in
                 handler(status)
             }
         }else{
             let request = CBAPIRequest(resource: CBAuthenticationResource(key: key, bundleId: bundleId, appName: appName))
-            authenticateRestClient(network: request, logger: logger,key: key, handler: handler)
+            authenticateRestClient(network: request, logger: logger, handler: handler)
         }
     }
     
-    func authenticateRestClient<T: CBNetworkRequest>(network: T, logger: CBLogger,key:String, handler: @escaping CBAuthenticationHandler) {
+    func authenticateRestClient<T: CBNetworkRequest>(network: T, logger: CBLogger, handler: @escaping CBAuthenticationHandler) {
         let (onSuccess, onError) = CBResult.buildResultHandlers(handler, logger)
         network.load(withCompletion: { status in
             if let data = status as? CBAuthenticationStatus {
-                CBCache.shared.saveAuthenticationDetails(key: key, data: data)
+                CBCache.shared.saveAuthenticationDetails(data: data)
                 onSuccess(data)
             }
         }, onError: onError)

--- a/Chargebee/Classes/Authentication/CBAuthentication.swift
+++ b/Chargebee/Classes/Authentication/CBAuthentication.swift
@@ -49,6 +49,9 @@ extension CBAuthenticationManager {
         if CBCache.shared.isCacheDataAvailable() {
             CBCache.shared.readConfigDetails(logger: logger) { status in
                 handler(status)
+            } onError: { error in
+                let request = CBAPIRequest(resource: CBAuthenticationResource(key: key, bundleId: bundleId, appName: appName))
+                self.authenticateRestClient(network: request, logger: logger, handler: handler)
             }
         }else{
             let request = CBAPIRequest(resource: CBAuthenticationResource(key: key, bundleId: bundleId, appName: appName))

--- a/Chargebee/Classes/Cache/CBCache.swift
+++ b/Chargebee/Classes/Cache/CBCache.swift
@@ -38,14 +38,12 @@ struct CBCache: CacheProtocal {
     }
     
     func createTime() -> Date {
-        
         let currentDate = Date()
         let newDate = NSDate(timeInterval: 86400, since: currentDate)
         return newDate as Date
     }
     
     func readConfigDetails(key: String,logger: CBLogger, handler: @escaping CBAuthenticationHandler){
-        
         let (onSuccess, _) = CBResult.buildResultHandlers(handler, logger)
         if let data = UserDefaults.standard.object(forKey: key) as? Data,
            let config = try? JSONDecoder().decode(ConfigCacheModel.self, from: data) {
@@ -56,12 +54,10 @@ struct CBCache: CacheProtocal {
     }
     
     func saveAuthenticationDetails(key: String,data: CBAuthenticationStatus) {
-        
         if let appId = data.details.appId,let status = data.details.status , let version = data.details.version{
             let configDetails = CBAuthentication.init(appId: appId, status: status, version: version)
             self.writeConfigDetails(key:key,object: configDetails)
         }
-        
     }
     
     func isCacheDataAvailable(key:String)-> Bool {
@@ -82,7 +78,6 @@ struct CBCache: CacheProtocal {
     }
     
     func clearCacheFromMemory(key:String){
-        
         if let data = UserDefaults.standard.object(forKey: key) as? Data,
            let config = try? JSONDecoder().decode(ConfigCacheModel.self, from: data) {
             if (config.config.appId != nil) || (config.config.status != nil) {

--- a/Chargebee/Classes/Cache/CBCache.swift
+++ b/Chargebee/Classes/Cache/CBCache.swift
@@ -30,7 +30,6 @@ struct CBCache: CacheProtocal {
     var todaysDate = NSDate()
     
     internal func writeConfigDetails(key:String, object configObject:CBAuthentication) {
-        debugPrint("Time created for 1 mint: \(createTime())")
         let configObj: ConfigCacheModel = ConfigCacheModel(config: configObject, date: createTime())
         if let encoded = try? JSONEncoder().encode(configObj) {
             UserDefaults.standard.set(encoded, forKey: key)

--- a/Chargebee/Classes/Cache/CBCache.swift
+++ b/Chargebee/Classes/Cache/CBCache.swift
@@ -19,7 +19,7 @@ private struct ConfigCacheModel: Codable {
 
 private protocol CacheProtocol {
     func writeConfigDetails(object:CBAuthentication)
-    func readConfigDetails(logger: CBLogger, handler: @escaping CBAuthenticationHandler)
+    func readConfigDetails(logger: CBLogger, withCompletion completion: @escaping (CBResult<CBAuthenticationStatus>) -> Void, onError: ErrorHandler?)
     func saveAuthenticationDetails(data: CBAuthenticationStatus)
     func isCacheDataAvailable()-> Bool
 }
@@ -28,7 +28,29 @@ internal struct CBCache: CacheProtocol {
     private let uniqueIdKey = "chargebee_config"
     static let shared = CBCache()
     
+    func readConfigDetails(logger: CBLogger, withCompletion completion: @escaping (CBResult<CBAuthenticationStatus>) -> Void, onError: ErrorHandler?) {
+        let (onSuccess, _) = CBResult.buildResultHandlers(completion, logger)
+        if let data = UserDefaults.standard.object(forKey: getFormattedkey()) as? Data,
+           let cacheModel = try? JSONDecoder().decode(ConfigCacheModel.self, from: data) {
+            let cacheObj = ConfigCacheModel(config: cacheModel.config, validTill: cacheModel.validTill)
+            let auth = CBAuthenticationStatus.init(details: cacheObj.config)
+            if ((auth.details.appId?.isEmpty) != nil) || ((auth.details.status?.isEmpty) != nil){
+                onSuccess(auth)
+            }else{
+                onError?(CBError.defaultSytemError(statusCode: 400, message:"Empty data found"))
+            }
+        }else{
+            onError?(CBError.defaultSytemError(statusCode: 400, message:"Failed to read config details from Cache"))
+        }
+    }
+    
     internal func writeConfigDetails(object configObject:CBAuthentication) {
+        if let data = UserDefaults.standard.object(forKey: getFormattedkey()) as? Data,
+           let cacheModel = try? JSONDecoder().decode(ConfigCacheModel.self, from: data) {
+            if ((cacheModel.config.appId?.isEmpty) != nil) {
+                UserDefaults.standard.removeObject(forKey: getFormattedkey())
+            }
+        }
         let configObj: ConfigCacheModel = ConfigCacheModel(config: configObject, validTill: createTime())
         if let encoded = try? JSONEncoder().encode(configObj) {
             UserDefaults.standard.set(encoded, forKey: getFormattedkey())
@@ -39,16 +61,6 @@ internal struct CBCache: CacheProtocol {
         let currentDate = Date()
         let newDate = NSDate(timeInterval: 86400, since: currentDate)
         return newDate as Date
-    }
-    
-    internal func readConfigDetails(logger: CBLogger, handler: @escaping CBAuthenticationHandler){
-        let (onSuccess, _) = CBResult.buildResultHandlers(handler, logger)
-        if let data = UserDefaults.standard.object(forKey: getFormattedkey()) as? Data,
-           let cacheModel = try? JSONDecoder().decode(ConfigCacheModel.self, from: data) {
-            let cacheObj = ConfigCacheModel(config: cacheModel.config, validTill: cacheModel.validTill)
-            let auth = CBAuthenticationStatus.init(details: cacheObj.config)
-            onSuccess(auth)
-        }
     }
     
     internal func saveAuthenticationDetails(data: CBAuthenticationStatus) {

--- a/Chargebee/Classes/Cache/CBCache.swift
+++ b/Chargebee/Classes/Cache/CBCache.swift
@@ -19,7 +19,7 @@ private struct ConfigCacheModel: Codable {
 
 private protocol CacheProtocol {
     func writeConfigDetails(object:CBAuthentication)
-    func readConfigDetails(logger: CBLogger, withCompletion completion: @escaping (CBResult<CBAuthenticationStatus>) -> Void, onError: ErrorHandler?)
+    func readConfigDetails(logger: CBLogger, withCompletion completion: @escaping (CBResult<CBAuthenticationStatus>) -> Void, onError: ErrorHandler)
     func saveAuthenticationDetails(data: CBAuthenticationStatus)
     func isCacheDataAvailable()-> Bool
 }
@@ -28,13 +28,13 @@ internal struct CBCache: CacheProtocol {
     private let uniqueIdKey = "chargebee_config"
     static let shared = CBCache()
     
-    func readConfigDetails(logger: CBLogger, withCompletion completion: @escaping (CBResult<CBAuthenticationStatus>) -> Void, onError: ErrorHandler?) {
+    func readConfigDetails(logger: CBLogger, withCompletion completion: @escaping (CBResult<CBAuthenticationStatus>) -> Void, onError: ErrorHandler) {
         let (onSuccess, _) = CBResult.buildResultHandlers(completion, logger)
         if let cacheModel = getCacheObject() {
             let auth = CBAuthenticationStatus.init(details: cacheModel.config)
             onSuccess(auth)
         }else{
-            onError?(CBError.defaultSytemError(statusCode: 400, message:"Failed to read config details from Cache"))
+            onError(CBError.defaultSytemError(statusCode: 400, message:"Failed to read config details from Cache"))
         }
     }
     

--- a/Chargebee/Classes/Cache/CBCache.swift
+++ b/Chargebee/Classes/Cache/CBCache.swift
@@ -10,14 +10,14 @@ import Foundation
 
 private struct ConfigCacheModel: Codable {
     var config: CBAuthentication
-    var savedDate: Date
-    init(config: CBAuthentication, savedDate: Date) {
+    var validTill: Date
+    init(config: CBAuthentication, validTill: Date) {
         self.config = config
-        self.savedDate = savedDate
+        self.validTill = validTill
     }
 }
 
-protocol CacheProtocol {
+private protocol CacheProtocol {
     func writeConfigDetails(object:CBAuthentication)
     func readConfigDetails(logger: CBLogger, handler: @escaping CBAuthenticationHandler)
     func saveAuthenticationDetails(data: CBAuthenticationStatus)
@@ -25,12 +25,11 @@ protocol CacheProtocol {
 }
 
 internal struct CBCache: CacheProtocol {
-    var uniqueIdKey = "chargebee_config"
+    private let uniqueIdKey = "chargebee_config"
     static let shared = CBCache()
-    var todaysDate = NSDate()
     
     internal func writeConfigDetails(object configObject:CBAuthentication) {
-        let configObj: ConfigCacheModel = ConfigCacheModel(config: configObject, savedDate: createTime())
+        let configObj: ConfigCacheModel = ConfigCacheModel(config: configObject, validTill: createTime())
         if let encoded = try? JSONEncoder().encode(configObj) {
             UserDefaults.standard.set(encoded, forKey: getFormattedkey())
         }
@@ -46,7 +45,7 @@ internal struct CBCache: CacheProtocol {
         let (onSuccess, _) = CBResult.buildResultHandlers(handler, logger)
         if let data = UserDefaults.standard.object(forKey: getFormattedkey()) as? Data,
            let cacheModel = try? JSONDecoder().decode(ConfigCacheModel.self, from: data) {
-            let cacheObj = ConfigCacheModel(config: cacheModel.config, savedDate: cacheModel.savedDate)
+            let cacheObj = ConfigCacheModel(config: cacheModel.config, validTill: cacheModel.validTill)
             let auth = CBAuthenticationStatus.init(details: cacheObj.config)
             onSuccess(auth)
         }
@@ -64,8 +63,8 @@ internal struct CBCache: CacheProtocol {
            let cacheModel = try? JSONDecoder().decode(ConfigCacheModel.self, from: data) {
             if let appID = cacheModel.config.appId ,let status = cacheModel.config.status {
                 if !appID.isEmpty && !status.isEmpty {
-                    let waitingDate:NSDate = cacheModel.savedDate as NSDate
-                    if (self.todaysDate.compare(waitingDate as Date) == ComparisonResult.orderedDescending) {
+                    let waitingDate:NSDate = cacheModel.validTill as NSDate
+                    if (Date().compare(waitingDate as Date) == ComparisonResult.orderedDescending) {
                         UserDefaults.standard.removeObject(forKey: getFormattedkey())
                         return false
                     }

--- a/Chargebee/Classes/Cache/CBCache.swift
+++ b/Chargebee/Classes/Cache/CBCache.swift
@@ -1,0 +1,93 @@
+//
+//  CBCache.swift
+//  Chargebee
+//
+//Created by ramesh_g on 28/07/23.
+//
+
+import Foundation
+
+
+struct ConfigCacheModel: Codable {
+    var config: CBAuthentication
+    var date: Date
+    init(config: CBAuthentication, date: Date) {
+        self.config = config
+        self.date = date
+    }
+}
+
+protocol CacheProtocal {
+    func writeConfigDetails(key:String,object:CBAuthentication)
+    func readConfigDetails(key:String,logger: CBLogger, handler: @escaping CBAuthenticationHandler)
+    func saveAuthenticationDetails(key:String,data: CBAuthenticationStatus)
+    func isCacheDataAvailable(key:String)-> Bool
+}
+
+struct CBCache: CacheProtocal {
+    
+    static let shared = CBCache()
+    var todaysDate = NSDate()
+    
+    internal func writeConfigDetails(key:String, object configObject:CBAuthentication) {
+        debugPrint("Time created for 1 mint: \(createTime())")
+        let configObj: ConfigCacheModel = ConfigCacheModel(config: configObject, date: createTime())
+        if let encoded = try? JSONEncoder().encode(configObj) {
+            UserDefaults.standard.set(encoded, forKey: key)
+        }
+    }
+    
+    func createTime() -> Date {
+        
+        let currentDate = Date()
+        let newDate = NSDate(timeInterval: 86400, since: currentDate)
+        return newDate as Date
+    }
+    
+    func readConfigDetails(key: String,logger: CBLogger, handler: @escaping CBAuthenticationHandler){
+        
+        let (onSuccess, _) = CBResult.buildResultHandlers(handler, logger)
+        if let data = UserDefaults.standard.object(forKey: key) as? Data,
+           let config = try? JSONDecoder().decode(ConfigCacheModel.self, from: data) {
+            let cacheObj = ConfigCacheModel(config: config.config, date: config.date)
+            let auth = CBAuthenticationStatus.init(details: cacheObj.config)
+            onSuccess(auth)
+        }
+    }
+    
+    func saveAuthenticationDetails(key: String,data: CBAuthenticationStatus) {
+        
+        if let appId = data.details.appId,let status = data.details.status , let version = data.details.version{
+            let configDetails = CBAuthentication.init(appId: appId, status: status, version: version)
+            self.writeConfigDetails(key:key,object: configDetails)
+        }
+        
+    }
+    
+    func isCacheDataAvailable(key:String)-> Bool {
+        if let data = UserDefaults.standard.object(forKey: key) as? Data,
+           let config = try? JSONDecoder().decode(ConfigCacheModel.self, from: data) {
+            if let appID = config.config.appId ,let status = config.config.status {
+                if !appID.isEmpty && !status.isEmpty {
+                    let waitingDate:NSDate = config.date as NSDate
+                    if (self.todaysDate.compare(waitingDate as Date) == ComparisonResult.orderedDescending) {
+                        self.clearCacheFromMemory(key: key)
+                        return false
+                    }
+                }
+                return true
+            }
+        }
+        return false
+    }
+    
+    func clearCacheFromMemory(key:String){
+        
+        if let data = UserDefaults.standard.object(forKey: key) as? Data,
+           let config = try? JSONDecoder().decode(ConfigCacheModel.self, from: data) {
+            if (config.config.appId != nil) || (config.config.status != nil) {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+    }
+}

--- a/Chargebee/Classes/Logger/CBLoggerResource.swift
+++ b/Chargebee/Classes/Logger/CBLoggerResource.swift
@@ -24,13 +24,7 @@ var osVersion: String {
 }
 
 var sdkVersion: String {
-
-    if let version = Bundle(for: Chargebee.self).infoDictionary?["CFBundleShortVersionString"] as? String, let build = Bundle(for: Chargebee.self).infoDictionary?["CFBundleVersion"] as? String {
-
-        return "\(version)-(\(build))"
-      }
-
-    return ""
+    return "1.0.26"
 }
 
 class CBLoggerResource: CBAPIResource {

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Choose from the following options to install Chargeee iOS SDK.
 Add the following snippet to the Podfile to install directly from Github.
 
 ```swift
-pod 'Chargebee', :git => 'https://github.com/chargebee/chargebee-ios', :tag => '1.0.25'
+pod 'Chargebee', :git => 'https://github.com/chargebee/chargebee-ios', :tag => '1.0.26'
 ```
 
 ### CocoaPods


### PR DESCRIPTION

Problem: Verify_Call App is getting called many time and increasing load on instances 
Solution: Verify call has been cached and it will hit once for every 24 hours.
Changes: Used UserDefaults for Caching in iOS SDK  , Verify or Authenticate response Cached and retrieved from cache to restrict  API call multiple times. 