### PR TITLE
NextOffet Value is Handled for Retrieve Subscriptions API

### DIFF
--- a/Chargebee.podspec
+++ b/Chargebee.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Chargebee'
-  s.version          = '1.0.26'
+  s.version          = '1.0.27'
   s.summary          = 'Chargebee iOS SDK'
 
 # This description is used to generate tags and improve search results.

--- a/Chargebee/Classes/Configuration/Chargebee.swift
+++ b/Chargebee/Classes/Configuration/Chargebee.swift
@@ -49,7 +49,7 @@ public class Chargebee {
         CBSubscriptionManager().retrieveSubscriptions(network: request, logger: logger, handler: handler)
     }
 
-    public func retrieveSubscriptionsList(queryParams: [String: String]? = nil, handler: @escaping RetrieveSubscriptionHandler) {
+    public func retrieveSubscriptions(queryParams: [String: String]? = nil, handler: @escaping RetrieveSubscriptionHandler) {
         let logger = CBLogger(name: "Subscription", action: "Fetch Subscription using customerId")
         logger.info()
         

--- a/Chargebee/Classes/Configuration/Chargebee.swift
+++ b/Chargebee/Classes/Configuration/Chargebee.swift
@@ -39,10 +39,10 @@ public class Chargebee {
         CBSubscriptionManager().retrieveSubscription(network: request, logger: logger, handler: handler)
     }
    
-    public func retrieveSubscriptions(queryParams: [String: String]? = nil, handler: @escaping SubscriptionHandler) {
+    public func retrieveSubscriptions(queryParams: [String: String]? = nil, handler: @escaping SubscriptionHandler2) {
         let logger = CBLogger(name: "Subscription", action: "Fetch Subscription using customerId")
         logger.info()
-
+        
         let request = CBAPIRequest(resource: SubscriptionResource(queryParams: queryParams))
         CBSubscriptionManager().retrieveSubscriptions(network: request, logger: logger, handler: handler)
     }

--- a/Chargebee/Classes/Configuration/Chargebee.swift
+++ b/Chargebee/Classes/Configuration/Chargebee.swift
@@ -39,7 +39,17 @@ public class Chargebee {
         CBSubscriptionManager().retrieveSubscription(network: request, logger: logger, handler: handler)
     }
    
-    public func retrieveSubscriptions(queryParams: [String: String]? = nil, handler: @escaping SubscriptionHandler2) {
+    
+    @available(*, deprecated, message: "This will be removed in upcoming versions, Please use this API func retrieveSubscriptionsList(queryParams: [String: String]? = nil, handler: @escaping RetrieveSubscriptionHandler)")
+    public func retrieveSubscriptions(queryParams: [String: String]? = nil, handler: @escaping SubscriptionHandler) {
+        let logger = CBLogger(name: "Subscription", action: "Fetch Subscription using customerId")
+        logger.info()
+        
+        let request = CBAPIRequest(resource: SubscriptionResource(queryParams: queryParams))
+        CBSubscriptionManager().retrieveSubscriptions(network: request, logger: logger, handler: handler)
+    }
+
+    public func retrieveSubscriptionsList(queryParams: [String: String]? = nil, handler: @escaping RetrieveSubscriptionHandler) {
         let logger = CBLogger(name: "Subscription", action: "Fetch Subscription using customerId")
         logger.info()
         

--- a/Chargebee/Classes/Configuration/Chargebee.swift
+++ b/Chargebee/Classes/Configuration/Chargebee.swift
@@ -40,7 +40,7 @@ public class Chargebee {
     }
    
     
-    @available(*, deprecated, message: "This will be removed in upcoming versions, Please use this API func retrieveSubscriptionsList(queryParams: [String: String]? = nil, handler: @escaping RetrieveSubscriptionHandler)")
+    @available(*, deprecated, message: "This will be removed in upcoming versions, Please use this API func retrieveSubscriptions(queryParams: [String: String]? = nil, handler: @escaping RetrieveSubscriptionHandler)")
     public func retrieveSubscriptions(queryParams: [String: String]? = nil, handler: @escaping SubscriptionHandler) {
         let logger = CBLogger(name: "Subscription", action: "Fetch Subscription using customerId")
         logger.info()

--- a/Chargebee/Classes/Logger/CBLoggerResource.swift
+++ b/Chargebee/Classes/Logger/CBLoggerResource.swift
@@ -24,7 +24,7 @@ var osVersion: String {
 }
 
 var sdkVersion: String {
-    return "1.0.26"
+    return "1.0.27"
 }
 
 class CBLoggerResource: CBAPIResource {

--- a/Chargebee/Classes/Subscription/CBSubscription.swift
+++ b/Chargebee/Classes/Subscription/CBSubscription.swift
@@ -76,7 +76,7 @@ class CBSubscriptionManager {
         network.load(withCompletion: { status in
             if let data = status as? CBSubscriptionWrapper {
                 if data.list.isEmpty {
-                    onError(CBError.defaultSytemError(statusCode: 480, message: "Subscription Not found"))
+                    onError(CBError.defaultSytemError(statusCode: 404, message: "Subscription Not found"))
                 }else{
                     onSuccess(data.list)
                 }
@@ -92,7 +92,7 @@ class CBSubscriptionManager {
         network.load(withCompletion: { status in
             if let data = status as? CBSubscriptionWrapper {
                 if data.list.isEmpty {
-                    onError(CBError.defaultSytemError(statusCode: 480, message: "Subscription Not found"))
+                    onError(CBError.defaultSytemError(statusCode: 404, message: "Subscription Not found"))
                 }else {
                     onSuccess(CBSubscriptionWrapper.init(list: data.list, nextOffset: data.nextOffset))
                 }

--- a/Chargebee/Classes/Subscription/CBSubscription.swift
+++ b/Chargebee/Classes/Subscription/CBSubscription.swift
@@ -94,7 +94,7 @@ class CBSubscriptionManager {
                 if data.list.isEmpty {
                     onError(CBError.defaultSytemError(statusCode: 404, message: "Subscription Not found"))
                 }else {
-                    onSuccess(CBSubscriptionWrapper.init(list: data.list, nextOffset: data.nextOffset))
+                    onSuccess(data)
                 }
             } else {
                 onError(CBError.defaultSytemError(statusCode: 480, message: "json serialization failure"))

--- a/Example/Chargebee/CBSDKSubscriptionStatusViewController.swift
+++ b/Example/Chargebee/CBSDKSubscriptionStatusViewController.swift
@@ -65,7 +65,7 @@ final class CBSDKSubscriptionStatusViewController: UIViewController {
         guard let id = subscriptioniDTextField.text, id.isNotEmpty else {
             return
         }
-        Chargebee.shared.retrieveSubscriptionsList(queryParams: ["customer_id": id,"offset":""]) { result in
+        Chargebee.shared.retrieveSubscriptions(queryParams: ["customer_id": id,"offset":""]) { result in
             switch result {
             case let .success(result):
                 debugPrint("Subscription Status Fetched: \(result)")
@@ -97,7 +97,7 @@ final class CBSDKSubscriptionStatusViewController: UIViewController {
             return
         }
         
-        Chargebee.shared.retrieveSubscriptionsList(queryParams: ["customer_id": id,"offset":offset]) { result in
+        Chargebee.shared.retrieveSubscriptions(queryParams: ["customer_id": id,"offset":offset]) { result in
             switch result {
             case let .success(result):
                 debugPrint("Subscription Status Fetched: \(result)")

--- a/Example/Chargebee/CBSDKSubscriptionStatusViewController.swift
+++ b/Example/Chargebee/CBSDKSubscriptionStatusViewController.swift
@@ -57,36 +57,84 @@ final class CBSDKSubscriptionStatusViewController: UIViewController {
     }
 
     @IBAction func getStatusUsingCustomerId(_ sender: Any) {
-        self.view.activityStartAnimating(activityColor: UIColor.white, backgroundColor: UIColor.black.withAlphaComponent(0.5))
-        
+        callRetreiveSubscriptions()
+    }
+    
+    func callRetreiveSubscriptions(){
+        self.activityStartAnimating()
         guard let id = subscriptioniDTextField.text, id.isNotEmpty else {
             return
         }
-        //Sample Query Params
-        //subscription_id ="id"
-        //status = "active"
-        Chargebee.shared.retrieveSubscriptions(queryParams: ["customer_id": id]) { result in
+        Chargebee.shared.retrieveSubscriptionsList(queryParams: ["customer_id": id,"offset":""]) { result in
+            switch result {
+            case let .success(result):
+                debugPrint("Subscription Status Fetched: \(result)")
+                if let value = result.nextOffset {
+                    let offset = value
+                    DispatchQueue.main.async {
+                        self.getSubcription(offset: offset)
+                    }
+                }else{
+                    DispatchQueue.main.async {
+                        if  let status = result.list.first?.subscription.status, let amount = result.list.first?.subscription.planAmount {
+                            let alertController = UIAlertController(title: "Chargebee", message: "Status :\(status)\n Plan amount:\(amount).", preferredStyle: .alert)
+                            alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+                            self.present(alertController, animated: true, completion: nil)
+                        }
+                    }
+                }
+                self.activityStopAnimating()
+            case let .error(error):
+                debugPrint("Error Fetched: \(error)")
+                self.showError(error: error)
+            }
+        }
+    }
+    
+    func getSubcription(offset: String){
+        self.activityStartAnimating()
+        guard let id = subscriptioniDTextField.text, id.isNotEmpty else {
+            return
+        }
+        
+        Chargebee.shared.retrieveSubscriptionsList(queryParams: ["customer_id": id,"offset":offset]) { result in
             switch result {
             case let .success(result):
                 debugPrint("Subscription Status Fetched: \(result)")
                 DispatchQueue.main.async {
-                    if  let status = result.first?.subscription.status, let amount = result.first?.subscription.planAmount {
+                    if  let status = result.list.first?.subscription.status, let amount = result.list.first?.subscription.planAmount {
                         let alertController = UIAlertController(title: "Chargebee", message: "Status :\(status)\n Plan amount:\(amount).", preferredStyle: .alert)
                         alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
                         self.present(alertController, animated: true, completion: nil)
                     }
-                    self.view.activityStopAnimating()
                 }
+                self.activityStopAnimating()
             case let .error(error):
                 debugPrint("Error Fetched: \(error)")
-                DispatchQueue.main.async {
-                    self.view.activityStopAnimating()
-                    self.statusLabel.text = error.localizedDescription
-                    self.subscriptioniDTextField.resignFirstResponder()
-                    
-                }
+                self.showError(error: error)
+                
             }
         }
+    }
+    
+    func activityStartAnimating(){
+        DispatchQueue.main.async {
+            self.view.activityStartAnimating(activityColor: UIColor.white, backgroundColor: UIColor.black.withAlphaComponent(0.5))
+        }
+    }
+    func activityStopAnimating(){
+        DispatchQueue.main.async {
+            self.view.activityStopAnimating()
+        }
+    }
+    
+    func showError(error:Error){
+        DispatchQueue.main.async {
+            self.view.activityStopAnimating()
+            self.statusLabel.text = error.localizedDescription
+            self.subscriptioniDTextField.resignFirstResponder()
+        }
+        self.activityStopAnimating()
     }
     @IBAction private func textFieldDidEndEdit(_ sender: UITextField) {
         enableFetchButton(shouldEnable: sender.isNotEmpty)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Choose from the following options to install Chargeee iOS SDK.
 Add the following snippet to the Podfile to install directly from Github.
 
 ```swift
-pod 'Chargebee', :git => 'https://github.com/chargebee/chargebee-ios', :tag => '1.0.26'
+pod 'Chargebee', :git => 'https://github.com/chargebee/chargebee-ios', :tag => '1.0.27'
 ```
 
 ### CocoaPods

--- a/README.md
+++ b/README.md
@@ -317,12 +317,13 @@ Use query parameters - Subscription ID, Customer ID, or Status for checking the 
 
 ```swift
 Chargebee.shared.retrieveSubscriptions(queryParams :["String" : "String"]") { result in
-    switch result {
-    case let .success(resultarray):
-        print("Status \(resultarray.first.subscription.status)")
-    case let .error(error):
-        // Handle error here
-    }
+  switch result {
+  case let .success(result):
+    print("Next offset \(result.nextOffset)")
+    print("Subscriptions: \(result.list)")
+  case let .error(error):
+    // Handle error here
+  }
 }
 ```
 


### PR DESCRIPTION
Overview:
Next Offset value is not handled for `retrieveSubscriptions` Method 
in this Pr we handled it and added a new public method  `retrieveSubscriptionsList` since the return handler is different from previous one could not able to mark it as deprecated on the existing method name `retrieveSubscriptions` so added new method name.
Changes made in  files `CBSubscriptionManager` and `Chargebee` and updated example App with the latest method.