### PR TITLE
customerId is returned in Purchase API handler

### DIFF
--- a/Chargebee/Classes/Authentication/CBAuthentication.swift
+++ b/Chargebee/Classes/Authentication/CBAuthentication.swift
@@ -45,7 +45,7 @@ extension CBAuthenticationManager {
         guard key.isNotEmpty else {
             return onError(CBError.defaultSytemError(statusCode: 400, message: "SDK Key is empty"))
         }
-        
+
         if CBCache.shared.isCacheDataAvailable() {
             CBCache.shared.readConfigDetails(logger: logger) { status in
                 handler(status)
@@ -53,12 +53,12 @@ extension CBAuthenticationManager {
                 let request = CBAPIRequest(resource: CBAuthenticationResource(key: key, bundleId: bundleId, appName: appName))
                 self.authenticateRestClient(network: request, logger: logger, handler: handler)
             }
-        }else{
+        } else {
             let request = CBAPIRequest(resource: CBAuthenticationResource(key: key, bundleId: bundleId, appName: appName))
             authenticateRestClient(network: request, logger: logger, handler: handler)
         }
     }
-    
+
     func authenticateRestClient<T: CBNetworkRequest>(network: T, logger: CBLogger, handler: @escaping CBAuthenticationHandler) {
         let (onSuccess, onError) = CBResult.buildResultHandlers(handler, logger)
         network.load(withCompletion: { status in

--- a/Chargebee/Classes/Authentication/CBAuthenticationResource.swift
+++ b/Chargebee/Classes/Authentication/CBAuthenticationResource.swift
@@ -37,8 +37,7 @@ final class CBAuthenticationResource: CBAPIResource {
         return urlRequest
     }
 
-    init(key: String, bundleId: String,
-         appName: String) {
+    init(key: String, bundleId: String, appName: String) {
         self.baseUrl = CBEnvironment.baseUrl
         self.requestBody = CBAuthenticationBody.init(key: key, bundleId: bundleId, appName: appName)
     }

--- a/Chargebee/Classes/Network/CBAPIRequest.swift
+++ b/Chargebee/Classes/Network/CBAPIRequest.swift
@@ -127,13 +127,13 @@ extension URLSession: NetworkSession {
 }
 
 struct NetworkClient {
-    
+
     func retrieve<T: CBNetworkRequest, U>(network: T, logger: CBLogger, handler: @escaping (CBResult<U>) -> Void) {
         let (onSuccess, onError) = CBResult.buildResultHandlers(handler, logger)
-        network.load(withCompletion: { result in            
+    network.load(withCompletion: { result in
             if let data = result as? U {
                 onSuccess(data)
-            }else{
+            } else {
                 onError(CBError.defaultSytemError(statusCode: 480, message: "json serialization failure"))
             }
         }, onError: onError)

--- a/Chargebee/Classes/Restore/BackgroundOperationQueue.swift
+++ b/Chargebee/Classes/Restore/BackgroundOperationQueue.swift
@@ -8,26 +8,26 @@
 import UIKit
 
 class BackgroundOperationQueue: OperationQueue {
-    
+
     private static var operationsKeyPath: String {
         return "operations"
     }
-    
+
     deinit {
         self.removeObserver(self, forKeyPath: "operations")
     }
-    
+
     var completionBlock: (() -> Void)? {
         didSet {
             self.addObserver(self, forKeyPath: BackgroundOperationQueue.operationsKeyPath, options: .new, context: nil)
         }
     }
-    
+
     override init() {
         super.init()
     }
-    
-    func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutableRawPointer) {
+
+    func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String: AnyObject]?, context: UnsafeMutableRawPointer) {
         if let operationPath = keyPath, operationPath == BackgroundOperationQueue.operationsKeyPath {
             if self.operations.isEmpty {
                 OperationQueue.main.addOperation({
@@ -36,6 +36,5 @@ class BackgroundOperationQueue: OperationQueue {
             }
         }
     }
-    
-}
 
+}

--- a/Chargebee/Classes/UIApplicationSettings/UIApplication+Settings.swift
+++ b/Chargebee/Classes/UIApplicationSettings/UIApplication+Settings.swift
@@ -11,19 +11,21 @@ import StoreKit
 
 extension UIApplication {
 
-    @objc class func showExternalManageSubscriptions() {
+    @objc class
+    func showExternalManageSubscriptions() {
         guard let url = URL(string: "https://apps.apple.com/account/subscriptions") else { return }
         self.shared.open(url, options: [:], completionHandler: nil)
     }
-    
+
     @available(iOS 15.0, *)
-    @objc class func showManageSubscriptions() {
+    @objc class
+    func showManageSubscriptions() {
         guard let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
               !ProcessInfo.processInfo.isiOSAppOnMac else {
                   UIApplication.showExternalManageSubscriptions()
                   return
         }
-        
+
         Task {
             do {
                 try await AppStore.showManageSubscriptions(in: scene)

--- a/Example/Chargebee/CBSDKProductsTableViewController.swift
+++ b/Example/Chargebee/CBSDKProductsTableViewController.swift
@@ -285,6 +285,8 @@ extension CBSDKProductsTableViewController: ProductTableViewCellDelegate {
                     print(result.status)
                     print(result.subscriptionId ?? "")
                     print(result.planId ?? "")
+                    print(result.customerId ?? "")
+
                     DispatchQueue.main.async {
                         self.view.activityStopAnimating()
                         let alertController = UIAlertController(title: "Chargebee", message: "success", preferredStyle: .alert)
@@ -354,7 +356,7 @@ extension CBSDKProductsTableViewController: ProductTableViewCellDelegate {
                 CBDemoPersistance.saveProductIdentifierOnPurchase(for: withProduct.product.productIdentifier)
             }
             self.view.activityStartAnimating(activityColor: UIColor.white, backgroundColor: UIColor.black.withAlphaComponent(0.5))
-            CBPurchase.shared.purchaseProduct(product: withProduct,customerId: customerID) { result in
+            CBPurchase.shared.purchaseProduct(product: withProduct, customerId: customerID) { result in
                 
                 print(result)
                 switch result {
@@ -362,6 +364,9 @@ extension CBSDKProductsTableViewController: ProductTableViewCellDelegate {
                     print(result.status)
                     print(result.subscriptionId ?? "")
                     print(result.planId ?? "")
+                    print(result.customerId ?? "")
+
+                    
 
                     DispatchQueue.main.async {
                         self.view.activityStopAnimating()


### PR DESCRIPTION
Improvements :

-  customerId is not handled in Purchase API return handler, updated now handled the customerId for the Purchase API handler.
-  Cleared swift lint warning issues in few files.