### PR TITLE
Forward all errors for Apple callback for restoreCompletedTransactions()

### DIFF
--- a/Chargebee/Classes/Purchase/CBPurchaseManager.swift
+++ b/Chargebee/Classes/Purchase/CBPurchaseManager.swift
@@ -278,9 +278,7 @@ extension CBPurchase: SKPaymentTransactionObserver {
     }
 
     public func paymentQueue(_ queue: SKPaymentQueue, restoreCompletedTransactionsFailedWithError error: Error) {
-        if let error = error as? RestoreError {
-            receiveRestoredTransactionsFinished(error)
-        }
+        receiveRestoredTransactionsFinished(error)
     }
 }
 

--- a/Chargebee/Classes/Restore/CBPurchaseManager+Extension.swift
+++ b/Chargebee/Classes/Restore/CBPurchaseManager+Extension.swift
@@ -17,7 +17,7 @@ extension CBPurchase {
         self.restoredPurchasesCount += 1
     }
     
-    func receiveRestoredTransactionsFinished(_ error: RestoreError?) {
+    func receiveRestoredTransactionsFinished(_ error: Error?) {
         if let error = error {
             debugPrint("Failed to restore purchases: \(error.localizedDescription)")
             self.restoreResponseHandler?(.failure(.restoreFailed))


### PR DESCRIPTION
Errors sent back from Apple in the delegate handler for restoreCompletedTransactions() - func paymentQueue(_ queue: SKPaymentQueue, restoreCompletedTransactionsFailedWithError error: Error) were being incorrectly casted to a Chargeable type error RestoreError so clients would never receive a failure callback in the event Apple sends an error type that is not convertible to RestoreError.
This removes that check, since the handling method receiveRestoredTransactionsFinished() does not even forward the error it receives, it simply logs it, discards it and replaces it with a RestoreError of type .restoreFailed in all cases an error exists.