### PR TITLE
Adds mobile token has auth header

### DIFF
--- a/Chargebee/Classes/Authentication/CBAuthenticationResource.swift
+++ b/Chargebee/Classes/Authentication/CBAuthenticationResource.swift
@@ -31,7 +31,9 @@ final class CBAuthenticationResource: CBAPIResource {
         })
         urlRequest.httpBody = bodyComponents.query?.data(using: .utf8)
         urlRequest.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-        urlRequest.addValue(authHeader!, forHTTPHeaderField: "Authorization")
+        if let resolvedAuthHeader = resolvedAuthHeader {
+            urlRequest.addValue(resolvedAuthHeader, forHTTPHeaderField: "Authorization")
+        }
         urlRequest.addValue(sdkVersion, forHTTPHeaderField: "version")
         urlRequest.addValue(platform, forHTTPHeaderField: "platform")
         return urlRequest

--- a/Chargebee/Classes/Configuration/CBEnvironment.swift
+++ b/Chargebee/Classes/Configuration/CBEnvironment.swift
@@ -4,6 +4,11 @@
 
 import Foundation
 
+/// Closure supplied by the App, which is responsible for returning a fresh mobile token from the server.
+/// The SDK invokes it during configure and whenever a request fails with a 401. The Server must mint a token via
+/// `create_mobile_token` and return the raw token to the App.
+public typealias CBMobileTokenProvider = (@escaping (String?) -> Void) -> Void
+
 class CBEnvironment {
     static var site: String = ""
     static var apiKey: String = ""
@@ -14,7 +19,13 @@ class CBEnvironment {
     static var version: CatalogVersion = .unknown
     static var session = URLSession.shared
     static var environment: String = "cb_ios_sdk"
-    
+    // When a mobile token is present, the SDK sends it for the `Authorization` similar to the publishable key.
+    // If empty, we fall back to the publishable key flow.
+    static var mobileToken: String = ""
+    static var tokenProvider: CBMobileTokenProvider?
+    static var encodedMobileToken: String {
+        return mobileToken.data(using: .utf8)?.base64EncodedString() ?? ""
+    }
 
     func configure(site: String, apiKey: String, allowErrorLogging: Bool, sdkKey: String? = nil) {
         let resultHandler: CBAuthenticationHandler = { result in
@@ -64,5 +75,56 @@ class CBEnvironment {
                     }
                 }
             }
+
+    // Mobile token flow: the SDK is configured without a publishable key. We fetch a token from
+    // the App's token provider and then verify the app details using it. If successful, the SDK is ready to use.
+    func configure(site: String, sdkKey: String? = nil, allowErrorLogging: Bool, tokenProvider: @escaping CBMobileTokenProvider, handler: @escaping CBAuthenticationHandler) {
+        CBEnvironment.site = site
+        CBEnvironment.apiKey = ""
+        CBEnvironment.encodedApiKey = ""
+        CBEnvironment.allowErrorLogging = allowErrorLogging
+        CBEnvironment.baseUrl = "https://\(site).chargebee.com/api"
+        CBEnvironment.version = .unknown
+        CBEnvironment.tokenProvider = tokenProvider
+        if let sdkKey = sdkKey {
+            CBEnvironment.sdkKey = sdkKey
+        }
+
+        let (onSuccess, onError) = CBResult.buildResultHandlers(handler, nil)
+        CBEnvironment.refreshMobileToken { success in
+            guard success else {
+                return onError(CBError.defaultSytemError(statusCode: 401, message: "Unable to fetch a mobile token from the token provider"))
+            }
+            guard CBEnvironment.sdkKey.isNotEmpty else {
+                // Nothing to verify without an SDK key; environment is ready.
+                return onSuccess(CBAuthenticationStatus(details: CBAuthentication(appId: nil, status: "ok", version: .unknown)))
+            }
+            CBAuthenticationManager().authenticate(forSDKKey: CBEnvironment.sdkKey) { result in
+                switch result {
+                case .success(let status):
+                    CBEnvironment.version = status.details.version ?? .unknown
+                    onSuccess(status)
+                case .error(let error):
+                    CBEnvironment.version = .unknown
+                    onError(error)
+                }
+            }
+        }
+    }
+
+    // Fetches a fresh token from the App's token provider and stores it.
+    static func refreshMobileToken(completion: @escaping (Bool) -> Void) {
+        guard let provider = tokenProvider else {
+            return completion(false)
+        }
+        provider { token in
+            if let token = token, token.isNotEmpty {
+                CBEnvironment.mobileToken = token
+                completion(true)
+            } else {
+                completion(false)
+            }
+        }
+    }
 
 }

--- a/Chargebee/Classes/Configuration/Chargebee.swift
+++ b/Chargebee/Classes/Configuration/Chargebee.swift
@@ -30,6 +30,14 @@ public class Chargebee {
                 }
             }
         }
+
+    /// Configures the SDK using a mobile token instead of a publishable API key.
+    /// The `tokenProvider` is called to obtain a token from the merchant's backend, both now and
+    /// whenever a request is rejected with a 401 (expired/revoked token).
+    public static func configure(site: String, sdkKey: String? = nil, allowErrorLogging: Bool = true, tokenProvider: @escaping CBMobileTokenProvider, handler: @escaping CBAuthenticationHandler) {
+        CBEnvironment.environment = self.environment
+        CBEnvironment().configure(site: site, sdkKey: sdkKey, allowErrorLogging: allowErrorLogging, tokenProvider: tokenProvider, handler: handler)
+    }
     
     public func retrieveSubscription(forSubscriptionID id: String, handler: @escaping CBSubscriptionHandler) {
         let logger = CBLogger(name: "Subscription", action: "Fetch Subscription")

--- a/Chargebee/Classes/Network/CBAPIRequest.swift
+++ b/Chargebee/Classes/Network/CBAPIRequest.swift
@@ -43,6 +43,15 @@ extension CBAPIResource {
         buildBaseRequest()
     }
 
+    // When a mobile token is configured we send it as `Authorization: Basic base64(token)` for every
+    // request (same scheme as the publishable key). Otherwise we fall back to the resource's own header.
+    var resolvedAuthHeader: String? {
+        if CBEnvironment.mobileToken.isNotEmpty {
+            return "Basic \(CBEnvironment.encodedMobileToken)"
+        }
+        return authHeader
+    }
+
     func create() -> URLRequest {
         var urlRequest = buildBaseRequest()
         urlRequest.httpMethod = "post"
@@ -64,7 +73,7 @@ extension CBAPIResource {
         }
 
         var urlRequest = URLRequest(url: components!.url!)
-        if let authHeader = authHeader {
+        if let authHeader = resolvedAuthHeader {
             urlRequest.addValue(authHeader, forHTTPHeaderField: "Authorization")
         }
         header?.forEach({ (key, value) in

--- a/Chargebee/Classes/Network/CBNetworkRequest.swift
+++ b/Chargebee/Classes/Network/CBNetworkRequest.swift
@@ -15,11 +15,25 @@ public protocol CBNetworkRequest {
 
 @available(macCatalyst 13.0, *)
 extension CBNetworkRequest {
-    func load(_ session: URLSession = URLSession.shared, urlRequest: URLRequest, withCompletion completion: SuccessHandler<ModelType>? = nil, onError: ErrorHandler? = nil) {
+    func load(_ session: URLSession = URLSession.shared, urlRequest: URLRequest, withCompletion completion: SuccessHandler<ModelType>? = nil, onError: ErrorHandler? = nil, allowRetry: Bool = true) {
 
         let task = CBEnvironment.session.dataTask(with: urlRequest, completionHandler: { (data: Data?, response: URLResponse?, error: Error?) -> Void in
             if let error = error {
                 onError?(CBError.defaultSytemError(statusCode: 400, message: error.localizedDescription))
+                return
+            }
+            // Mobile token expired/revoked: fetch a fresh token from the merchant backend and retry once.
+            if let response = response as? HTTPURLResponse, response.statusCode == 401,
+               allowRetry, CBEnvironment.tokenProvider != nil {
+                CBEnvironment.refreshMobileToken { success in
+                    guard success else {
+                        onError?(self.buildCBError(data, statusCode: 401))
+                        return
+                    }
+                    var retryRequest = urlRequest
+                    retryRequest.setValue("Basic \(CBEnvironment.encodedMobileToken)", forHTTPHeaderField: "Authorization")
+                    self.load(session, urlRequest: retryRequest, withCompletion: completion, onError: onError, allowRetry: false)
+                }
                 return
             }
             if let response = response as? HTTPURLResponse, response.statusCode >= 400 {

--- a/Example/Chargebee/AppDelegate.swift
+++ b/Example/Chargebee/AppDelegate.swift
@@ -15,10 +15,32 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application
-        Chargebee.configure(site: "cb-abc-test",
-                            apiKey: "API-KEY", sdkKey: "SDK-KEY", allowErrorLogging: false)
+        // Configure the SDK with a mobile token fetched from your server instead of
+        // embedding a publishable API key in the app.
+        Chargebee.configure(
+            site: "cb-abc-test",
+            sdkKey: "SDK-KEY",
+            tokenProvider: { completion in
+                // Ask your server for a fresh mobile token (it mints one via
+                // `create_mobile_token`), then hand the raw token back to the SDK.
+                AppDelegate.fetchMobileToken(completion: completion)
+            },
+            handler: { result in
+                switch result {
+                case .success(let status):
+                    debugPrint("Chargebee configured: \(status)")
+                case .error(let error):
+                    debugPrint("Chargebee configuration failed: \(error)")
+                }
+            }
+        )
 
        return true
+    }
+
+    /// Stand-in for the call to your own server that returns a Chargebee mobile token.
+    /// Replace the body with a real network request to your server.
+    private static func fetchMobileToken(completion: @escaping (String?) -> Void) {
+        completion("cb_mob_replace_with_token_from_your_backend")
     }
 }


### PR DESCRIPTION
## CHANGELOG
REPLACE_ME_WITH_CHANGELOG

## SUMMARY
REPLACE_ME_WITH_SUMMARY_OF_THE_CHANGES

## FUNCTIONAL AUTOMATION CHANGES PR
- [ ] Yes
  - If Yes, PR : 
- [ ] No
  - If No, Reason: 

## AUTOMATION TEST REPORT URL
REPLACE_ME_WITH_TEST_REPORT_URL

## AREAS OF IMPACT
REPLACE_ME_WITH_AREAS_OF_IMPACT_OR_NA

## TYPE OF CHANGE
- [ ] 🐞 Bugfix
- [ ] 🌟 Feature
- [ ] ✨ Enhancement
- [ ] 🧪 Unit Test Cases
- [ ] 📔 Documentation
- [ ] ⚙️ Chore - Build Related / Configuration / Others


## DOCUMENTATION
REPLACE_ME_WITH_DOCUMENTATION_LINK_OR_NA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds mobile-token authentication through a new `Chargebee.configure` overload and token provider. Resolves mobile-token authorization headers, supports token refresh, and retries one HTTP 401 response. Updates the example app to use token-based configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->